### PR TITLE
Arbitrum One and Arbitrum Sepolia Integration

### DIFF
--- a/config/networks/arbitrum-one.json
+++ b/config/networks/arbitrum-one.json
@@ -1,0 +1,17 @@
+{
+  "network": "arbitrum-one",
+  "chainId": "42161",
+  "displayName": "Arbitrum One",
+  "identityRegistry": {
+    "address": "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    "startBlock": 428895443
+  },
+  "reputationRegistry": {
+    "address": "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    "startBlock": 428895443
+  },
+  "validationRegistry": {},
+  "graphNode": {
+    "network": "arbitrum-one"
+  }
+}

--- a/config/networks/arbitrum-sepolia.json
+++ b/config/networks/arbitrum-sepolia.json
@@ -1,0 +1,17 @@
+{
+  "network": "arbitrum-sepolia",
+  "chainId": "421614",
+  "displayName": "Arbitrum Sepolia",
+  "identityRegistry": {
+    "address": "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    "startBlock": 239945838
+  },
+  "reputationRegistry": {
+    "address": "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    "startBlock": 239945838
+  },
+  "validationRegistry": {},
+  "graphNode": {
+    "network": "arbitrum-sepolia"
+  }
+}

--- a/deployments/deployment.json
+++ b/deployments/deployment.json
@@ -102,6 +102,28 @@
           "schema": "1.0.0",
           "subgraph": "1.0.0"
         }
+      },
+      "erc-8004-arbitrum-sepolia": {
+        "network": "arbitrum-sepolia",
+        "displayName": "Arbitrum Sepolia",
+        "chainId": "421614",
+        "status": "prod",
+        "configFile": "config/networks/arbitrum-sepolia.json",
+        "versions": {
+          "schema": "1.0.0",
+          "subgraph": "1.0.0"
+        }
+      },
+      "erc-8004-arbitrum-one": {
+        "network": "arbitrum-one",
+        "displayName": "Arbitrum One",
+        "chainId": "42161",
+        "status": "prod",
+        "configFile": "config/networks/arbitrum-one.json",
+        "versions": {
+          "schema": "1.0.0",
+          "subgraph": "1.0.0"
+        }
       }
     }
   }

--- a/src/contract-addresses.ts
+++ b/src/contract-addresses.ts
@@ -99,6 +99,24 @@ export function getContractAddresses(chainId: BigInt): ContractAddresses {
       Bytes.fromHexString("0x34ae1196b1609e01ebc90b75c802b2ea87203f13")
     )
   }
+  // Arbitrum Sepolia Testnet (421614)
+  else if (chainId.equals(BigInt.fromString("421614"))) {
+    return new ContractAddresses(
+      Bytes.fromHexString("0x8004A818BFB912233c491871b3d84c89A494BD9e"),
+      Bytes.fromHexString("0x8004B663056A597Dffe9eCcC1965A193B7388713"),
+      // Validation registry not configured / indexing paused
+      Bytes.fromHexString("0x0000000000000000000000000000000000000000")
+    )
+  }
+  // Arbitrum One (Mainnet) (42161)
+  else if (chainId.equals(BigInt.fromString("42161"))) {
+    return new ContractAddresses(
+      Bytes.fromHexString("0x8004A169FB4a3325136EB29fA0ceB6D2e539a432"),
+      Bytes.fromHexString("0x8004BAa17C55a88189AE136b182e5fdA19dE9b63"),
+      // Validation registry not configured / indexing paused
+      Bytes.fromHexString("0x0000000000000000000000000000000000000000")
+    )
+  }
 
   // Unsupported chain - return zero addresses
   return new ContractAddresses(
@@ -122,6 +140,8 @@ export function getChainName(chainId: BigInt): string {
   if (chainId.equals(BigInt.fromI32(296))) return "Hedera Testnet"
   if (chainId.equals(BigInt.fromI32(998))) return "HyperEVM Testnet"
   if (chainId.equals(BigInt.fromString("1351057110"))) return "SKALE Base Sepolia Testnet"
+  if (chainId.equals(BigInt.fromI32(421614))) return "Arbitrum Sepolia"
+  if (chainId.equals(BigInt.fromI32(42161))) return "Arbitrum One"
   return `Unsupported Chain ${chainId.toString()}`
 }
 
@@ -150,14 +170,16 @@ export function isSupportedChain(chainId: BigInt): boolean {
 
 export function getSupportedChains(): BigInt[] {
   return [
-    BigInt.fromI32(1),             // Ethereum Mainnet
-    BigInt.fromI32(137),           // Polygon Mainnet
-    BigInt.fromI32(11155111),      // Ethereum Sepolia
-    BigInt.fromI32(84532),         // Base Sepolia
-    BigInt.fromI32(59141),         // Linea Sepolia
-    BigInt.fromI32(80002),         // Polygon Amoy
-    BigInt.fromI32(296),           // Hedera Testnet
-    BigInt.fromI32(998),           // HyperEVM Testnet
-    BigInt.fromString("1351057110") // SKALE Base Sepolia Testnet
+    BigInt.fromI32(1),               // Ethereum Mainnet
+    BigInt.fromI32(137),             // Polygon Mainnet
+    BigInt.fromI32(11155111),        // Ethereum Sepolia
+    BigInt.fromI32(84532),           // Base Sepolia
+    BigInt.fromI32(59141),           // Linea Sepolia
+    BigInt.fromI32(80002),           // Polygon Amoy
+    BigInt.fromI32(296),             // Hedera Testnet
+    BigInt.fromI32(998),             // HyperEVM Testnet
+    BigInt.fromString("1351057110"), // SKALE Base Sepolia Testnet
+    BigInt.fromI32(421614),          // Arbitrum Sepolia
+    BigInt.fromI32(42161)            // Arbitrum One (Mainnet)
   ]
 }

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -26,6 +26,8 @@ export function getChainId(): i32 {
     return 998  // HyperEVM Testnet
   } else if (network == "skale-base-sepolia-testnet") {
     return 1351057110  // SKALE Base Sepolia Testnet
+  } else if (network == "arbitrum-sepolia") {
+    return 421614 // Arbitrum Sepolia Testnet
   }
   // Mainnets (for future use)
   else if (network == "mainnet") {
@@ -37,7 +39,7 @@ export function getChainId(): i32 {
   } else if (network == "polygon" || network == "matic") {
     return 137
   } else if (network == "arbitrum-one") {
-    return 42161
+    return 42161 // Arbitrum One (Mainnet)
   } else if (network == "optimism") {
     return 10
   } else if (network == "bsc") {


### PR DESCRIPTION
This pull request introduces the configurations necessary to deploy subgraphs for the ERC-8004 Identity and Reputation registries on Arbitrum One and Arbitrum Sepolioa.

**Check list:**
Contracts deployed to target network - Done
Contract addresses obtained (lowercase)  - Done

     Arbitrum Sepolia: 
          Identity: 0x8004A818BFB912233c491871b3d84c89A494BD9e
          Reputation: 0x8004B663056A597Dffe9eCcC1965A193B7388713

     Arbitrum One:
          Identity: 0x8004A169FB4a3325136EB29fA0ceB6D2e539a432
          Reputation: 0x8004BAa17C55a88189AE136b182e5fdA19dE9b63
          
          
Deployment block numbers found - Done

     Arbitrum Sepolia (earliest block number: 239945838):
          Identity: https://sepolia.arbiscan.io/tx/0x1eca6a0ff79a4b697d0cc9b7f568b3e364525bfe36d9076157cc5ccc045c5db7
          Reputation: https://sepolia.arbiscan.io/tx/0xe5d09a2abc5e0fd5f7b9fa872e23e90e81bbc24f8b7e7c52be644614d8e203e1

     Arbitrum One (earliest block number: 428895443)
          Identity: https://arbiscan.io/tx/0x3e8aa4f329d4218ebf6d2c7eef0856ec4b65a37b8620e3a1b4eed62a8f24b7b8
          Reputation: https://arbiscan.io/tx/0x85ac65c1c6a2721889d874a488d290a668c88512de3d25c5fece0480010184f2

Created config/networks/<network>.json - Done
Updated deployments/deployment.json - Done
Updated src/utils/chain.ts (chain ID mapping) - Done
Updated src/contract-addresses.ts (addresses + chain name) - Done
Ran npm run validate (passed) - Done
Ran npm run generate (manifest created) - Done

Ran build test (successful) - Failed
This doesn't seem to work at the moment
 npm run test gives: 
 Downloading release from https://github.com/LimeChain/matchstick/releases/download/0.6.0/binary-linux-20
Error fetching release: Request failed with status code 404

Created subgraph in Studio (correct network) - Done

Deployed to Studio (successful) - Done

**Arbitrum Sepolia Subgraph:** https://thegraph.com/explorer/subgraphs/6WuFQqo3FR5F76fCR4Bkfnymu64S5iu2tgX7JZsxQxg9?view=Query&chain=arbitrum-one
**Arbitrum One Subgraph:** https://thegraph.com/explorer/subgraphs/HZ6yKjjbYpkLTXLJBxfe4HWN3jxkLfLNJXh4zeVj1t9L?view=Query&chain=arbitrum-one

Verified indexing started - Complete
Tested queries in Playground - Complete