### PR TITLE
feat: add Unichain Sepolia subgraph deployment

### DIFF
--- a/config/networks/unichain-sepolia.json
+++ b/config/networks/unichain-sepolia.json
@@ -1,0 +1,22 @@
+{
+  "network": "unichain-testnet",
+  "chainId": "1301",
+  "displayName": "Unichain Sepolia",
+
+  "identityRegistry": {
+    "address": "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    "startBlock": 44938190
+  },
+  "reputationRegistry": {
+    "address": "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    "startBlock": 44938269
+  },
+  "validationRegistry": {
+    "address": "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+    "startBlock": 44938313
+  },
+
+  "graphNode": {
+    "network": "unichain-testnet"
+  }
+}

--- a/deployments/deployment.json
+++ b/deployments/deployment.json
@@ -102,7 +102,18 @@
           "schema": "1.0.0",
           "subgraph": "1.0.0"
         }
+      },
+      "erc-8004-unichain-sepolia": {
+        "network": "unichain-testnet",
+        "displayName": "Unichain Sepolia",
+        "chainId": "1301",
+        "status": "prod",
+        "configFile": "config/networks/unichain-sepolia.json",
+        "versions": {
+        "schema": "1.0.0",
+        "subgraph": "1.0.0"
       }
     }
+  }
   }
 }

--- a/src/contract-addresses.ts
+++ b/src/contract-addresses.ts
@@ -100,6 +100,15 @@ export function getContractAddresses(chainId: BigInt): ContractAddresses {
     )
   }
 
+  // Unichain Sepolia (1301)
+else if (chainId.equals(BigInt.fromI32(1301))) {
+  return new ContractAddresses(
+    Bytes.fromHexString("0x8004A818BFB912233c491871b3d84c89A494BD9e"),
+    Bytes.fromHexString("0x8004B663056A597Dffe9eCcC1965A193B7388713"),
+    Bytes.fromHexString("0x8004Cb1BF31DAf7788923b405b754f57acEB4272")
+  )
+}
+
   // Unsupported chain - return zero addresses
   return new ContractAddresses(
     Bytes.fromHexString("0x0000000000000000000000000000000000000000"),
@@ -122,6 +131,7 @@ export function getChainName(chainId: BigInt): string {
   if (chainId.equals(BigInt.fromI32(296))) return "Hedera Testnet"
   if (chainId.equals(BigInt.fromI32(998))) return "HyperEVM Testnet"
   if (chainId.equals(BigInt.fromString("1351057110"))) return "SKALE Base Sepolia Testnet"
+  if (chainId.equals(BigInt.fromI32(1301))) return "Unichain Sepolia"
   return `Unsupported Chain ${chainId.toString()}`
 }
 
@@ -132,7 +142,7 @@ export function getChainName(chainId: BigInt): string {
 export function validateContractAddresses(addresses: ContractAddresses): boolean {
   // Check if addresses are not zero addresses
   let zeroAddress = Bytes.fromHexString("0x0000000000000000000000000000000000000000")
-  
+
   // Validation registry is currently optional because validation indexing is paused in the manifest.
   // We still store it in `Protocol`, but do not require it to consider a chain supported.
   return !addresses.identityRegistry.equals(zeroAddress) &&
@@ -158,6 +168,7 @@ export function getSupportedChains(): BigInt[] {
     BigInt.fromI32(80002),         // Polygon Amoy
     BigInt.fromI32(296),           // Hedera Testnet
     BigInt.fromI32(998),           // HyperEVM Testnet
-    BigInt.fromString("1351057110") // SKALE Base Sepolia Testnet
+    BigInt.fromString("1351057110"), // SKALE Base Sepolia Testnet
+    BigInt.fromI32(1301)           // Unichain Sepolia
   ]
 }

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -26,6 +26,8 @@ export function getChainId(): i32 {
     return 998  // HyperEVM Testnet
   } else if (network == "skale-base-sepolia-testnet") {
     return 1351057110  // SKALE Base Sepolia Testnet
+  } else if (network == "unichain-testnet") {
+    return 1301  // UniChain Sepolia
   }
   // Mainnets (for future use)
   else if (network == "mainnet") {


### PR DESCRIPTION
## Summary

Adds **Unichain Sepolia** network support for the ERC-8004 subgraph.

Contracts were deployed in:
https://github.com/erc-8004/erc-8004-contracts/pull/55

---

## Changes

- Add Unichain Sepolia network configuration
- Register new deployment in `deployment.json`
- Add chainId mapping (1301)
- Add contract address resolution
- Set start blocks for all registries

---

## Contract Addresses

IdentityRegistry  
https://unichain-sepolia.blockscout.com/address/0x8004A818BFB912233c491871b3d84c89A494BD9e

ReputationRegistry  
https://unichain-sepolia.blockscout.com/address/0x8004B663056A597Dffe9eCcC1965A193B7388713

ValidationRegistry  
https://unichain-sepolia.blockscout.com/address/0x8004Cb1BF31DAf7788923b405b754f57acEB4272

---

## Subgraph Deployment

Graph Studio:
https://thegraph.com/studio/subgraph/erc-8004-unichain-sepolia/

Build and deployment completed successfully.  
Indexing starts from the configured start blocks.

---

## Notes

- Network identifier: `unichain-testnet`
- Chain ID: `1301`
- Deterministic vanity addresses aligned with other testnets
- No schema or mapping logic changes